### PR TITLE
Fixed a bug where pushable blocks would not correctly save/load/reset the block they were last standing on

### DIFF
--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -929,14 +929,6 @@ bool Block::loadFromNode(ImageManager&, SDL_Renderer&, TreeStorageNode* objNode)
 	return true;
 }
 
-void Block::prepareFrame(){
-	//Reset the delta variables.
-	dx=dy=0;
-	//Also reset the velocity, these should be set in the move method.
-	if(type!=TYPE_PUSHABLE)
-		xVel=yVel=0;
-}
-
 void Block::move(){
 	bool isPlayMode = stateID != STATE_LEVEL_EDITOR || dynamic_cast<LevelEditor*>(parent)->isPlayMode();
 

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -35,8 +35,8 @@ Block::Block(Game* parent,int x,int y,int w,int h,int type):
 	temp(0),
 	tempSave(0),
 	dx(0),
-	dxSave(0),
 	dy(0),
+	dxSave(0),
 	dySave(0),
 	movingPosTime(-1),
 	speed(0),
@@ -94,7 +94,7 @@ void Block::init(int x,int y,int w,int h,int type){
 		parent->shadow.fy=box.y;
 	}
 
-	objCurrentStand=NULL;
+	objCurrentStand=objCurrentStandSave=NULL;
 	inAir=inAirSave=true;
 	xVel=yVel=xVelBase=yVelBase=0;
 	xVelSave=yVelSave=xVelBaseSave=yVelBaseSave=0;
@@ -271,6 +271,7 @@ void Block::saveState(){
 	//In case of a certain blocks we need to save some more.
 	switch(type){
 		case TYPE_PUSHABLE:
+			objCurrentStandSave=objCurrentStand;
 			xVelBaseSave=xVelBase;
 			yVelBaseSave=yVelBase;
 			inAirSave=inAir;
@@ -304,6 +305,7 @@ void Block::loadState(){
 	//Handle block type specific variables.
 	switch(type){
 		case TYPE_PUSHABLE:
+			objCurrentStand=objCurrentStandSave;
 			xVelBase=xVelBaseSave;
 			yVelBase=yVelBaseSave;
 			inAir=inAirSave;
@@ -366,9 +368,12 @@ void Block::reset(bool save){
 			}
 			break;
 		case TYPE_PUSHABLE:
+			objCurrentStand=NULL;
 			inAir=false;
-			if(save)
+			if(save) {
+				objCurrentStandSave=NULL;
 				inAirSave=false;
+			}
 			break;
 		case TYPE_CONVEYOR_BELT:
 		case TYPE_SHADOW_CONVEYOR_BELT:

--- a/src/Block.h
+++ b/src/Block.h
@@ -200,8 +200,6 @@ public:
 	//Returns: True if it succeeds without errors.
     virtual bool loadFromNode(ImageManager&, SDL_Renderer&, TreeStorageNode* objNode) override;
 
-	//Method used for resetting the dx/dy and xVel/yVel variables.
-	virtual void prepareFrame();
 	//Method used for updating moving blocks or elements of blocks.
 	virtual void move();
 

--- a/src/Block.h
+++ b/src/Block.h
@@ -83,6 +83,7 @@ private:
 
 	//Following is for the pushable block.
 	Block* objCurrentStand;
+	Block* objCurrentStandSave;
 
 	//Flags of the block for the editor.
 	int editorFlags;

--- a/src/Block.h
+++ b/src/Block.h
@@ -144,8 +144,8 @@ public:
 	//boxType: The type of box that should be returned.
 	//See GameObjects.h for the types.
 	//Returns: The box.
-	virtual SDL_Rect getBox(int boxType=BoxType_Current);
-	
+	virtual SDL_Rect getBox(int boxType=BoxType_Current) override;
+
 	//Method for setting the block to a given location as if it moved there.
 	//x: The new x location.
 	//y: The new y location.
@@ -157,43 +157,43 @@ public:
 	void growTo(int w,int h);
 
 	//Save the state of the block so we can load it later on.
-	virtual void saveState();
+	virtual void saveState() override;
 	//Load the saved state of the block so.
-	virtual void loadState();
+	virtual void loadState() override;
 	//Reset the block.
 	//save: Boolean if the saved state should also be deleted.
-	virtual void reset(bool save);
+	virtual void reset(bool save) override;
 	
 	//Play an animation.
-	virtual void playAnimation();
+	virtual void playAnimation() override;
 	
 	//Method called when there's an event.
 	//eventType: The type of event.
 	//See GameObjects.h for the eventtypes.
-	virtual void onEvent(int eventType);
+	virtual void onEvent(int eventType) override;
 	
 	//Method used to retrieve a property from the block.
 	//propertyType: The type of property requested.
 	//See GameObjects.h for the properties.
 	//obj: Pointer to the player.
 	//Returns: Integer containing the value of the property.
-	virtual int queryProperties(int propertyType,Player* obj);
+	virtual int queryProperties(int propertyType,Player* obj) override;
 	
 	//Get the editor data of the block.
 	//obj: The vector that will be filled with the editorData.
-	virtual void getEditorData(std::vector<std::pair<std::string,std::string> >& obj);
+	virtual void getEditorData(std::vector<std::pair<std::string,std::string> >& obj) override;
 	//Set the editor data of the block.
 	//obj: The new editor data.
-	virtual void setEditorData(std::map<std::string,std::string>& obj);
+	virtual void setEditorData(std::map<std::string,std::string>& obj) override;
 
 	//Get a single property of the block.
 	//property: The property to return.
 	//Returns: The value for the requested property.
-	virtual std::string getEditorProperty(std::string property);
+	virtual std::string getEditorProperty(std::string property) override;
 	//Set a single property of the block.
 	//property: The property to set.
 	//value: The new value for the property.
-	virtual void setEditorProperty(std::string property,std::string value);
+	virtual void setEditorProperty(std::string property,std::string value) override;
 
 	//Method for loading the Block from a node.
 	//objNode: Pointer to the storage node to load from.
@@ -201,7 +201,7 @@ public:
     virtual bool loadFromNode(ImageManager&, SDL_Renderer&, TreeStorageNode* objNode) override;
 
 	//Method used for updating moving blocks or elements of blocks.
-	virtual void move();
+	virtual void move() override;
 
 	//Get total time ot moving positions.
 	int getPathMaxTime();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -538,12 +538,6 @@ void Game::logic(ImageManager& imageManager, SDL_Renderer& renderer){
 	//Add one tick to the time.
 	time++;
 
-	//FIXME:Resetting dx/dy and xVel/yVel every loop interferes with movement logic of player and blocks.
-	//First prepare each gameObject for the new frame.
-	//This includes resetting dx/dy and xVel/yVel.
-	//for(unsigned int o=0;o<levelObjects.size();o++)
-		//levelObjects[o]->prepareFrame();
-
 	//Process delay execution scripts.
 	getScriptExecutor()->processDelayExecution();
 

--- a/src/GameObjects.cpp
+++ b/src/GameObjects.cpp
@@ -79,5 +79,4 @@ void GameObject::setEditorProperty(std::string property,std::string value){}
 
 bool GameObject::loadFromNode(ImageManager&, SDL_Renderer&, TreeStorageNode*){return true;}
 
-void GameObject::prepareFrame(){}
 void GameObject::move(){}

--- a/src/GameObjects.h
+++ b/src/GameObjects.h
@@ -167,9 +167,6 @@ public:
 	//Returns: True if it succeeds without errors.
     virtual bool loadFromNode(ImageManager&, SDL_Renderer&, TreeStorageNode*);
 
-	//Method that is called before the move method.
-	//It can be used to reset variables like delta movement and velocity.
-	virtual void prepareFrame();
 	//Update method for GameObjects, used for moving blocks.
 	virtual void move();
 };

--- a/src/Scenery.cpp
+++ b/src/Scenery.cpp
@@ -390,11 +390,6 @@ bool Scenery::updateCustomScenery(ImageManager& imageManager, SDL_Renderer& rend
 	return true;
 }
 
-void Scenery::prepareFrame(){
-	//Reset the delta variables.
-	dx=dy=0;
-}
-
 void Scenery::move(){
 	//Update our appearance.
 	appearance.updateAnimation();

--- a/src/Scenery.h
+++ b/src/Scenery.h
@@ -93,52 +93,52 @@ public:
 	//boxType: The type of box that should be returned.
 	//See GameObjects.h for the types.
 	//Returns: The box.
-	virtual SDL_Rect getBox(int boxType=BoxType_Current);
+	virtual SDL_Rect getBox(int boxType=BoxType_Current) override;
 	
 	//Method used to set the location of the scenery.
 	//NOTE: The new location isn't stored as base location.
 	//x: The new x location.
 	//y: The new y location.
-	virtual void setLocation(int x,int y);
+	virtual void setLocation(int x,int y) override;
 
 	//Save the state of the scenery so we can load it later on.
-	virtual void saveState();
+	virtual void saveState() override;
 	//Load the saved state of the scenery.
-	virtual void loadState();
+	virtual void loadState() override;
 	//Reset the scenery.
 	//save: Boolean if the saved state should also be deleted.
-	virtual void reset(bool save);
+	virtual void reset(bool save) override;
 	
 	//Play an animation.
-	virtual void playAnimation();
+	virtual void playAnimation() override;
 	
 	//Method called when there's an event.
 	//eventType: The type of event.
 	//See GameObjects.h for the eventtypes.
-	virtual void onEvent(int eventType);
+	virtual void onEvent(int eventType) override;
 	
 	//Method used to retrieve a property from the scenery.
 	//propertyType: The type of property requested.
 	//See GameObjects.h for the properties.
 	//obj: Pointer to the player.
 	//Returns: Integer containing the value of the property.
-	virtual int queryProperties(int propertyType,Player* obj);
+	virtual int queryProperties(int propertyType,Player* obj) override;
 	
 	//Get the editor data of the scenery.
 	//obj: The vector that will be filled with the editorData.
-	virtual void getEditorData(std::vector<std::pair<std::string,std::string> >& obj);
+	virtual void getEditorData(std::vector<std::pair<std::string,std::string> >& obj) override;
 	//Set the editor data of the scenery.
 	//obj: The new editor data.
-	virtual void setEditorData(std::map<std::string,std::string>& obj);
+	virtual void setEditorData(std::map<std::string,std::string>& obj) override;
 
 	//Get a single property of the scenery.
 	//property: The property to return.
 	//Returns: The value for the requested property.
-	virtual std::string getEditorProperty(std::string property);
+	virtual std::string getEditorProperty(std::string property) override;
 	//Set a single property of the scenery.
 	//property: The property to set.
 	//value: The new value for the property.
-	virtual void setEditorProperty(std::string property,std::string value);
+	virtual void setEditorProperty(std::string property,std::string value) override;
 
 	//Method for loading the Scenery object from a node.
 	//objNode: Pointer to the storage node to load from.
@@ -146,7 +146,7 @@ public:
     virtual bool loadFromNode(ImageManager& imageManager,SDL_Renderer& renderer,TreeStorageNode* objNode) override;
 
 	//Method used for updating any animations.
-	virtual void move();
+	virtual void move() override;
 };
 
 #endif

--- a/src/Scenery.h
+++ b/src/Scenery.h
@@ -145,8 +145,6 @@ public:
 	//Returns: True if it succeeds without errors.
     virtual bool loadFromNode(ImageManager& imageManager,SDL_Renderer& renderer,TreeStorageNode* objNode) override;
 
-	//Method used for resetting the dx/dy and xVel/yVel variables.
-	virtual void prepareFrame();
 	//Method used for updating any animations.
 	virtual void move();
 };


### PR DESCRIPTION
While testing out the pushable blocks, I noticed some occasional strange behaviour when resetting the level in the editor. I tracked it down to the fact that the `objCurrentStand` of the pushable block was not reset correctly. On top of that it wasn't even being saved/loaded meaning it could have strange side-effects.

There are some unrelated changes/cleanup as well, which I did while going through the code.