### PR TITLE
Some bugfixes (focus/selection in GUITextBox and adding/removing links in LevelEditor)

### DIFF
--- a/src/Commands.h
+++ b/src/Commands.h
@@ -249,6 +249,9 @@ private:
 	
 	//Previous id of target.
 	std::string id;
+
+	//Previous switch/button that was linked to target (can be NULL)
+	Block* oldTrigger;
 public: 
 	AddLinkCommand(LevelEditor* levelEditor, Block* linkingTrigger, GameObject* clickedObject);
 	

--- a/src/GUIObject.cpp
+++ b/src/GUIObject.cpp
@@ -197,8 +197,9 @@ int GUIObject::getSelectedControl() {
 	for (int i = 0; i < (int)childControls.size(); i++) {
 		GUIObject *obj = childControls[i];
 		if (obj && obj->visible && obj->enabled && obj->state) {
-			if (dynamic_cast<GUIButton*>(obj) || dynamic_cast<GUICheckBox*>(obj)
-				|| dynamic_cast<GUITextBox*>(obj) || dynamic_cast<GUISpinBox*>(obj)
+			if ((dynamic_cast<GUITextBox*>(obj) || dynamic_cast<GUISpinBox*>(obj)) && obj->state == 2) {
+				return i;
+			} else if (dynamic_cast<GUIButton*>(obj) || dynamic_cast<GUICheckBox*>(obj)
 				|| dynamic_cast<GUISingleLineListBox*>(obj)
 				|| dynamic_cast<GUISlider*>(obj)
 				)

--- a/src/GUIObject.h
+++ b/src/GUIObject.h
@@ -310,6 +310,7 @@ public:
 
 	//Method used to update selection.
 	void updateSelection(int start, int end);
+	void blur();
 private:
 	//Text highlights.
 	int highlightStart;


### PR DESCRIPTION
A few bugs I encountered while testing. The GUITextBox behaved weirdly when holding left mouse button and hovering over other text boxes. Basically multiple carrots would show up (one in each text box) and random selections/highlights. The commits basically limit selecting to the text box that is currently in focus _OR_ the one below the cursor when starting a selection.

Perhaps we should introduce a `focus`, `blur` and `hasFocus` on the base GUIObject and let all types implement it appropriately, which will help improve the keyboard navigation (which is already really nice :wink: ).

Finally there is a bug fix in the LevelEditor. When connecting multiple switches/buttons to the same target object, the editor would incorrectly think both would trigger the object, while in fact only the last one would. (Thinking about it, we might want to support it for V0.6, as I can think of interesting puzzles if you have a 'on' switch and an 'off' switch both connected to the same control).