### PR TITLE
Render the full game state + dim + GUIOverlay every frame, instead of just the overlay

### DIFF
--- a/src/GUIOverlay.cpp
+++ b/src/GUIOverlay.cpp
@@ -111,8 +111,7 @@ void GUIOverlay::enterLoop(ImageManager& imageManager, SDL_Renderer& renderer, b
 		inputMgr.updateState(false);
 
 		//Render the gui.
-		if(GUIObjectRoot)
-            GUIObjectRoot->render(renderer);
+		render(imageManager,renderer);
 
 		/*//draw new achievements (if any)
 		statsMgr.render();*/
@@ -145,7 +144,21 @@ void GUIOverlay::logic(ImageManager&, SDL_Renderer&){
 		delete this;
 }
 
-void GUIOverlay::render(ImageManager&, SDL_Renderer&){}
+void GUIOverlay::render(ImageManager& imageManager, SDL_Renderer& renderer) {
+	//Render the parentState in full, including GUI
+	parentState->render(imageManager,renderer);
+	if(tempGUIObjectRoot) {
+		tempGUIObjectRoot->render(renderer);
+	}
+
+	//Draw the overlay on top
+	if(dim) {
+		dimScreen(renderer);
+	}
+	if(GUIObjectRoot) {
+		GUIObjectRoot->render(renderer);
+	}
+}
 
 void GUIOverlay::resize(ImageManager& imageManager, SDL_Renderer& renderer){
 	//We recenter the GUI.
@@ -165,11 +178,6 @@ void GUIOverlay::resize(ImageManager& imageManager, SDL_Renderer& renderer){
 
 	//And set the GUIObjectRoot back to the overlay gui.
 	GUIObjectRoot=root;
-
-	//Dim the background.
-	if(dim){
-        dimScreen(renderer);
-	}
 }
 
 AddonOverlay::AddonOverlay(SDL_Renderer &renderer, GUIObject* root, GUIButton *cancelButton, GUITextArea *textArea, int keyboardNavigationMode)

--- a/src/GUIOverlay.h
+++ b/src/GUIOverlay.h
@@ -62,7 +62,7 @@ public:
     //Inherited from GameState.
     void handleEvents(ImageManager&, SDL_Renderer&) override;
     void logic(ImageManager&, SDL_Renderer&) override;
-    void render(ImageManager&, SDL_Renderer&) override;
+    void render(ImageManager& imageManager, SDL_Renderer& renderer) override;
     void resize(ImageManager& imageManager, SDL_Renderer& renderer) override;
 };
 


### PR DESCRIPTION
This seems to work fine for both the `msgBox` overlays that enter their own update/render loop and other usages of `GUIOverlay`.