### PR TITLE
Engine support for ngettext

### DIFF
--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -1028,7 +1028,8 @@ MoveToLayerCommand::~MoveToLayerCommand() {
 }
 
 std::string MoveToLayerCommand::describe() {
-	return tfm::format(_("Move %d object(s) from layer %s to layer %s"), objects.size(), oldName, newName);
+	const size_t number_of_objects = objects.size();
+	return tfm::format(ngettext("Move %d objects from layer %s to layer %s", "Move %d objects from layer %s to layer %s", number_of_objects), number_of_objects, oldName, newName);
 }
 
 void MoveToLayerCommand::removeGameObject() {

--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -94,6 +94,12 @@ Settings* settings=nullptr;
 
 SDL_Renderer* sdlRenderer=nullptr;
 
+const char* ngettext(const char* message,const char* messageplural,int num) {
+	return (dictionaryManager!=NULL) ?
+					dictionaryManager->get_dictionary().translate_plural(message,messageplural,num).c_str() :
+				std::string(messageplural).c_str();
+}
+
 void applySurface(int x,int y,SDL_Surface* source,SDL_Surface* dest,SDL_Rect* clip){
 	//The offset is needed to draw at the right location.
 	SDL_Rect offset;

--- a/src/Functions.h
+++ b/src/Functions.h
@@ -50,6 +50,13 @@ class ImageManager;
 struct SDL_Texture;
 class LevelPackManager;
 
+//gettext function for plural forms
+//message: Thesingular version of the message to translate.
+//messageplural: The plural version of the message to translate.
+//num: The number to fetch the plural form for
+//Returns: The translated string or the original string if there is not translation available.
+const char* ngettext(const char* message, const char* messageplural, int num);
+
 //Method for drawing an SDL_Surface onto another.
 //x: The x location to draw the source on the desination.
 //y: The y location to draw the source on the desination.

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1050,7 +1050,7 @@ void Game::render(ImageManager&,SDL_Renderer &renderer){
                                      textureFromTextShaded(
                                          renderer,
                                          *fontText,
-                                         tfm::format(_("%d recordings"),recordings).c_str(),
+                                         tfm::format(ngettext("%d recording","%d recordings",recordings),recordings).c_str(),
                                          fg,
                                          bg
                                      ));

--- a/src/LevelEditor.cpp
+++ b/src/LevelEditor.cpp
@@ -1705,7 +1705,8 @@ std::string MoveGameObjectCommand::describe() {
 			: describeSceneryName(scenery->sceneryName_).c_str())
 			: _(blockNames[objects[0]->type]));
 	} else {
-		return tfm::format(_("Move %d objects"), objects.size());
+		const size_t number_of_objects = objects.size();
+		return tfm::format(ngettext("Move %d object", "Move %d objects", number_of_objects), objects.size());
 	}
 }
 
@@ -1717,7 +1718,8 @@ std::string AddRemoveGameObjectCommand::describe() {
 			: describeSceneryName(scenery->sceneryName_).c_str())
 			: _(blockNames[objects[0]->type]));
 	} else {
-		return tfm::format(isAdd ? _("Add %d objects") : _("Remove %d objects"), objects.size());
+		const size_t number_of_objects = objects.size();
+		return tfm::format(isAdd ? ngettext("Add %d object", "Add %d objects", number_of_objects) : ngettext("Remove %d object", "Remove %d objects", number_of_objects), objects.size());
 	}
 }
 


### PR DESCRIPTION
Added support for translation with correct plural forms to engine.

Some notes:
1. Having a macro would probably be better for consistency, but I kept getting compiler errors, so I wrote a function instead
2.  I did not commit the changes from running `messages.pot.sh` to keep the diff small.
3. I don't know where to find the affected strings on-screen, so that still needs testing.