### PR TITLE
Avoid paths with double slashes

### DIFF
--- a/src/Addons.cpp
+++ b/src/Addons.cpp
@@ -57,10 +57,10 @@ Addons::Addons(SDL_Renderer &renderer, ImageManager &imageManager)
 	title = titleTextureFromText(renderer, _("Addons"), objThemes.getTextColor(false), SCREEN_WIDTH);
 
 	//Load placeholder addon icons and screenshot.
-	addonIcon["levels"] = imageManager.loadImage(getDataPath() + "/gfx/addon1.png");
-	addonIcon["levelpacks"] = imageManager.loadImage(getDataPath() + "/gfx/addon2.png");
-	addonIcon["themes"] = imageManager.loadImage(getDataPath() + "/gfx/addon3.png");
-	addonIcon[std::string()] = imageManager.loadImage(getDataPath() + "/gfx/addon0.png");
+	addonIcon["levels"] = imageManager.loadImage(getDataPath() + "gfx/addon1.png");
+	addonIcon["levelpacks"] = imageManager.loadImage(getDataPath() + "gfx/addon2.png");
+	addonIcon["themes"] = imageManager.loadImage(getDataPath() + "gfx/addon3.png");
+	addonIcon[std::string()] = imageManager.loadImage(getDataPath() + "gfx/addon0.png");
 
 	//Load predefined categories.
 	if (categoryNameMap.empty()) {
@@ -70,7 +70,7 @@ Addons::Addons(SDL_Renderer &renderer, ImageManager &imageManager)
 		}
 	}
 
-	screenshot=imageManager.loadTexture(getDataPath()+"/gfx/screenshot.png", renderer);
+	screenshot=imageManager.loadTexture(getDataPath()+"gfx/screenshot.png", renderer);
 	
 	//Clear the GUI if any.
 	if(GUIObjectRoot){

--- a/src/CreditsMenu.cpp
+++ b/src/CreditsMenu.cpp
@@ -39,7 +39,7 @@ Credits::Credits(ImageManager& imageManager,SDL_Renderer& renderer){
 
 	//Open the AUTHORS file and read every line.
 	{
-		ifstream fin((getDataPath()+"/../AUTHORS").c_str());
+		ifstream fin((getDataPath()+"../AUTHORS").c_str());
 		if(!fin.is_open()) {
 			cerr<<"ERROR: Unable to open the AUTHORS file."<<endl;
 			credits.push_back("ERROR: Unable to open the AUTHORS file.");
@@ -58,7 +58,7 @@ Credits::Credits(ImageManager& imageManager,SDL_Renderer& renderer){
 	
 	//Open the Credits.text file and read every line.
 	{
-		ifstream fin((getDataPath()+"/Credits.txt").c_str());
+		ifstream fin((getDataPath()+"Credits.txt").c_str());
 		if(!fin.is_open()) {
 			cerr<<"ERROR: Unable to open the Credits.txt file."<<endl;
 			credits.push_back("ERROR: Unable to open the Credits.txt file.");

--- a/src/LevelPack.cpp
+++ b/src/LevelPack.cpp
@@ -148,7 +148,7 @@ bool LevelPack::loadLevels(const std::string& levelListFile){
 			//Folder is present so configure the levelDictionaryManager.
 			dictionaryManager=new tinygettext::DictionaryManager();
 			dictionaryManager->set_use_fuzzy(false);
-			dictionaryManager->add_directory(pathFromFileName(levelListFile)+"locale/");
+			dictionaryManager->add_directory(pathFromFileName(levelListFile)+"locale");
 			dictionaryManager->set_charset("UTF-8");
 			dictionaryManager->set_language(tinygettext::Language::from_name(language));
 		}else{


### PR DESCRIPTION
As `getDataPath()` already returns a path that ends with a slash, there is no need to double slashes for those strings